### PR TITLE
Remove toolforge.redirect_to_https() call

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,8 +22,6 @@ import messages
 app = flask.Flask(__name__)
 app.jinja_env.add_extension('jinja2.ext.do')
 
-app.before_request(toolforge.redirect_to_https)
-
 toolforge.set_user_agent('sgoab-object-annotator', email='albin.larsson@europeana.eu')
 user_agent = requests.utils.default_user_agent()
 


### PR DESCRIPTION
The function was removed from the module after the HTTPS migration was completed.

---

I just had a brief outage in one of my tools because I still had this line in there and it crashed on a new venv (with a newer version of the `toolforge` library). Essentially, this is a time bomb waiting to go off the next time you run `pip install --upgrade`. I did a GitHub code search and found it here as well, so let’s remove it :)